### PR TITLE
Fix for Linux.

### DIFF
--- a/crostouchscreen2/atmel.cpp
+++ b/crostouchscreen2/atmel.cpp
@@ -613,15 +613,15 @@ Status
 
 	PATMEL_CONTEXT pDevice = GetDeviceContext(FxDevice);
 	
-	if (FxTargetState != 5) {
 
 	if (pDevice->multitouch == MXT_TOUCH_MULTITOUCHSCREEN_T100)
 		mxt_set_t7_power_cfg(pDevice, MXT_POWER_CFG_DEEPSLEEP);
 	else {
+		if (FxTargetState != 5) {
 		struct mxt_object *obj = mxt_findobject(&pDevice->core, MXT_TOUCH_MULTI_T9);
 		mxt_write_object_off(pDevice, obj, MXT_T9_CTRL, 0);
-	}
-	
+		
+		}
 	}
 
 	WdfTimerStop(pDevice->Timer, TRUE);

--- a/crostouchscreen2/atmel.cpp
+++ b/crostouchscreen2/atmel.cpp
@@ -590,7 +590,7 @@ Status
 NTSTATUS
 OnD0Exit(
 	_In_  WDFDEVICE               FxDevice,
-	_In_  WDF_POWER_DEVICE_STATE  FxPreviousState
+	_In_  WDF_POWER_DEVICE_STATE  FxTargetState
 )
 /*++
 
@@ -601,7 +601,7 @@ This routine destroys objects needed by the driver.
 Arguments:
 
 FxDevice - a handle to the framework device object
-FxPreviousState - previous power state
+FxTargetState - the target power state
 
 Return Value:
 
@@ -609,15 +609,19 @@ Status
 
 --*/
 {
-	UNREFERENCED_PARAMETER(FxPreviousState);
+	UNREFERENCED_PARAMETER(FxTargetState);
 
 	PATMEL_CONTEXT pDevice = GetDeviceContext(FxDevice);
+	
+	if (FxTargetState != 5) {
 
 	if (pDevice->multitouch == MXT_TOUCH_MULTITOUCHSCREEN_T100)
 		mxt_set_t7_power_cfg(pDevice, MXT_POWER_CFG_DEEPSLEEP);
 	else {
 		struct mxt_object *obj = mxt_findobject(&pDevice->core, MXT_TOUCH_MULTI_T9);
 		mxt_write_object_off(pDevice, obj, MXT_T9_CTRL, 0);
+	}
+	
 	}
 
 	WdfTimerStop(pDevice->Timer, TRUE);


### PR DESCRIPTION
This fix allows the touchscreen to work on reboot to Linux. It does not affect Windows power management in hibernation, sleep, or Fast Shutdown. The fix is only triggered when Exit is to WdfPowerDeviceD3Final, which is State 5 seen here:

https://msdn.microsoft.com/en-us/library/windows/hardware/ff552421(v=vs.85).aspx

FxPreviousState is also renamed to FxTargetState in accordance with the descriptions here:


https://msdn.microsoft.com/en-us/library/windows/hardware/ff556803(v=vs.85).aspx

https://github.com/Microsoft/Windows-driver-samples/blob/master/sensors/SimpleDeviceOrientationSensor/device.cpp#L537

This change is neutral to Windows functionality but provides an alternative to cold booting to get the touchscreen to work in Linux